### PR TITLE
add password show/hide button to input group

### DIFF
--- a/components/inputGroup.tsx
+++ b/components/inputGroup.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { useState } from 'react';
 
 interface InputGroupProps {
   className?: string;
@@ -7,6 +8,7 @@ interface InputGroupProps {
   value: string;
   error: string | undefined;
   setValue: (str: string) => void;
+  password?: boolean;
 }
 
 const InputGroup: React.FC<InputGroupProps> = ({
@@ -16,11 +18,16 @@ const InputGroup: React.FC<InputGroupProps> = ({
   value,
   error,
   setValue,
+  password,
 }) => {
+  const [hiddenPassword, setHiddenPassword] = useState(true);
+
+  const toggleHidden = () => setHiddenPassword(!hiddenPassword);
+
   return (
     <div className={className}>
       <input
-        type={type}
+        type={hiddenPassword ? type : 'text'}
         className={classNames('input-postitt', {
           'border-red-500': error,
         })}
@@ -28,6 +35,13 @@ const InputGroup: React.FC<InputGroupProps> = ({
         value={value}
         onChange={(e) => setValue(e.target.value)}
       />
+      {password ? (
+        <span className="absolute right-0 py-2 pr-3 text-xl text-gray-400" onClick={toggleHidden}>
+          {hiddenPassword ? <i className="far fa-eye-slash"></i> : <i className="far fa-eye"></i>}
+        </span>
+      ) : (
+        ''
+      )}
       <small className="font-medium text-red-600">{error}</small>
     </div>
   );

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -71,24 +71,8 @@ export default function LoginPage() {
               setValue={setPassword}
               placeholder="Password"
               error={errors.password}
+              password
             />
-            {/* TODO: #34 Make the password input have the eye icon span */}
-            {/* <div className="relative flex flex-wrap items-stretch w-full mb-8">
-              <input
-                id="password"
-                type="password"
-                name="password"
-                className={classNames('input-postitt', {
-                  'border-red-500': errors.password,
-                })}
-                placeholder="Password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-              <span className="absolute right-0 z-10 items-center justify-center w-8 h-full py-3 pr-3 text-base font-normal leading-snug text-center text-gray-400 bg-transparent">
-                <i className="far fa-eye-slash"></i>
-              </span>
-            </div> */}
             <button type="submit" className="w-full my-3 btn-postitt">
               Login
             </button>

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -96,28 +96,8 @@ export default function RegisterPage() {
                   setValue={setPassword}
                   placeholder="Password"
                   error={errors.password}
+                  password
                 />
-
-                {/* <div className="relative flex flex-wrap items-stretch w-full mb-8">
-              <input
-                id="password"
-                type="password"
-                name="password"
-                className={classNames('input-postitt', {
-                  'border-red-500': errors.password,
-                })}
-                placeholder="Password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-              <span className="absolute right-0 z-10 items-center justify-center w-8 h-full py-3 pr-3 text-base font-normal leading-snug text-center text-gray-400 bg-transparent">
-                <i className="far fa-eye-slash"></i>
-              </span>
-            </div>
-            <small className="font-medium text-red-600">
-              {errors.password} 
-             </small> */}
-
                 <input
                   type="checkbox"
                   className="mr-1 cursor-pointer"


### PR DESCRIPTION
This PR adds the password show/hide functionality to the InputGroup component

When the user clicks the eye icon the input will toggle from type 'password' to text

to use this, an additional prop must be passed 'password' to the component as you will see in the code review.

The component will check and apply the eye span if necessary 


![image](https://user-images.githubusercontent.com/70609396/107436206-26920d80-6b25-11eb-88ca-74178189b65e.png)


![image](https://user-images.githubusercontent.com/70609396/107436191-1e39d280-6b25-11eb-831a-be1fda838b2f.png)



closes #34 